### PR TITLE
update modeling-tic-tac-toe naming

### DIFF
--- a/exercises/modelling-tictactoe.edn
+++ b/exercises/modelling-tictactoe.edn
@@ -7,7 +7,7 @@
                 "`_|_|X`"
                 "`O|_|_`"
                 "In your model, include a history of the moves played."
-                "Write a function `turns-played` that returns how many turns have been played."]
+                "Write a function `moves-played` that returns how many moves have been played."]
  :solution [(def game-state
               {:current-player "X"
                :board [nil "X" "O"


### PR DESCRIPTION
The function on the `modeling-tic-tac-toe` exercise mentions a function name that does not exist in the example solution. This updates the exercise information to use the name of the function that exists in the example solution. 

I went with the `moves-played` nomenclature because sometimes `turns` can potentially be ambiguous to mean both players have played their move and it constitutes one "turn", the data appears to model more of a "move" based system so I just stuck with the naming found in the sample.